### PR TITLE
Correçao de erro de sintaxe

### DIFF
--- a/STL/README.md
+++ b/STL/README.md
@@ -540,10 +540,10 @@ map<int,int> mapa;
 // codigo que preenche o map
 
 	//iterator!
-for(auto i = mapa.begin(),i != mapa.end(); i++){
+for(auto i = mapa.begin();i != mapa.end(); i++){
 	// Os *pares* chave valor do map funcionam como um pair (Duh!) 
 					
-	printf("%d %d\n",(*i.first),(*i).second);
+	printf("%d %d\n",(*i).first,(*i).second);
 }
 ```
 


### PR DESCRIPTION
Correção de vírgula que estava no lugar de um poto e vírgula, e parenteses devidamente posicionados agora.